### PR TITLE
#CW-708: fix ssl context init error prevents query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ local.properties
 /target/
 
 .DS_Store
+dependency-reduced-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
 		<dependency>
 			<groupId>org.ndexbio</groupId>
 			<artifactId>ndex-object-model</artifactId>
-			<version>2.5.7-SNAPSHOT</version>
+			<version>2.5.7</version>
 		</dependency>
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
@@ -108,6 +108,31 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<repositories>
+		<repository>
+			<id>cytoscape_snapshots</id>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<name>Cytoscape Snapshots</name>
+			<url>https://nrnb-nexus.ucsd.edu/repository/cytoscape_snapshots/</url>
+		</repository>
+		<repository>
+			<id>cytoscape_releases</id>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<name>Cytoscape Releases</name>
+			<url>https://nrnb-nexus.ucsd.edu/repository/cytoscape_releases/</url>
+		</repository>
+	</repositories>
 
 	<dependencyManagement>
 		<dependencies>

--- a/src/main/java/org/ndexbio/SingleNetworkSolrIdxManager.java
+++ b/src/main/java/org/ndexbio/SingleNetworkSolrIdxManager.java
@@ -34,6 +34,11 @@ import java.io.IOException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.net.ssl.SSLContext;
+
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrServerException;
@@ -68,12 +73,31 @@ public class SingleNetworkSolrIdxManager implements AutoCloseable{
 
 	/**
 	 * Constructor
-	 * 
+	 *
 	 * @param networkUUID name of network aka collection
 	 * @param solrURL base SOLR URL
 	 */
 	public SingleNetworkSolrIdxManager(String networkUUID, final String solrURL){
-		this(new HttpJdkSolrClient.Builder(solrURL).withDefaultCollection(networkUUID).build());
+		this(buildSolrClient(networkUUID, solrURL));
+	}
+
+	// HttpJdkSolrClient uses Java's built-in HttpClient which eagerly calls
+	// SSLContext.getDefault() even for plain HTTP connections. On Java 21 this
+	// triggers DefaultSSLContext initialization which fails in some server
+	// environments (broken JCE provider / Cipher.getInstance failure). Providing
+	// an explicit TLS context bypasses getDefault() entirely.
+	private static HttpSolrClientBase buildSolrClient(String networkUUID, String solrURL) {
+		SSLContext sslContext;
+		try {
+			sslContext = SSLContext.getInstance("TLS");
+			sslContext.init(null, null, null);
+		} catch (NoSuchAlgorithmException | KeyManagementException e) {
+			throw new RuntimeException("Failed to initialize SSL context for Solr client: " + e.getMessage(), e);
+		}
+		return new HttpJdkSolrClient.Builder(solrURL)
+				.withDefaultCollection(networkUUID)
+				.withSSLContext(sslContext)
+				.build();
 	}
 	
 	/**


### PR DESCRIPTION
fix ssl init errors thrown on query requests:

```
14:57:55.438 [qtp1476394199-34] INFO MessageResource -- Neighorhood Query term: cd27
14:57:55.438 [qtp1476394199-34] INFO MessageResource -- Neighorhood Query edgeLimit: 10000
java.lang.NoClassDefFoundError: Could not initialize class sun.security.ssl.SSLContextImpl$DefaultSSLContext
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:421)
	at java.base/java.lang.Class.forName(Class.java:412)
	at java.base/java.security.Provider$Service.getImplClass(Provider.java:1993)
	at java.base/java.security.Provider$Service.getDefaultConstructor(Provider.java:2024)
	at java.base/java.security.Provider$Service.newInstanceOf(Provider.java:1938)
	at java.base/java.security.Provider$Service.newInstanceUtil(Provider.java:1946)
	at java.base/java.security.Provider$Service.newInstance(Provider.java:1921)
	at java.base/sun.security.jca.GetInstance.getInstance(GetInstance.java:236)
	at java.base/sun.security.jca.GetInstance.getInstance(GetInstance.java:164)
	at java.base/javax.net.ssl.SSLContext.getInstance(SSLContext.java:185)
	at java.base/javax.net.ssl.SSLContext.getDefault(SSLContext.java:110)
	at java.net.http/jdk.internal.net.http.HttpClientImpl.<init>(HttpClientImpl.java:460)
	at java.net.http/jdk.internal.net.http.HttpClientImpl.create(HttpClientImpl.java:436)
	at java.net.http/jdk.internal.net.http.HttpClientBuilderImpl.build(HttpClientBuilderImpl.java:143)
	at org.apache.solr.client.solrj.impl.HttpJdkSolrClient.<init>(HttpJdkSolrClient.java:133)
	at org.apache.solr.client.solrj.impl.HttpJdkSolrClient$Builder.build(HttpJdkSolrClient.java:583)
	at org.ndexbio.SingleNetworkSolrIdxManager.<init>(SingleNetworkSolrIdxManager.java:76)
	at org.ndexbio.SingleNetworkSolrIdxManager.<init>(SingleNetworkSolrIdxManager.java:85)
	at org.ndexbio.MessageResource.findStartingNodeIds(MessageResource.java:120)
	at org.ndexbio.MessageResource.queryNetwork(MessageResource.java:191)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.jboss.resteasy.core.MethodInjectorImpl.invoke(MethodInjectorImpl.java:154)
	at org.jboss.resteasy.core.MethodInjectorImpl.invoke(MethodInjectorImpl.java:118)
	at org.jboss.resteasy.core.ResourceMethodInvoker.internalInvokeOnTarget(ResourceMethodInvoker.java:560)
	at org.jboss.resteasy.core.ResourceMethodInvoker.invokeOnTargetAfterFilter(ResourceMethodInvoker.java:452)
	at org.jboss.resteasy.core.ResourceMethodInvoker.lambda$invokeOnTarget$2(ResourceMethodInvoker.java:413)
	at org.jboss.resteasy.core.interception.jaxrs.PreMatchContainerRequestContext.filter(PreMatchContainerRequestContext.java:321)
	at org.jboss.resteasy.core.ResourceMethodInvoker.invokeOnTarget(ResourceMethodInvoker.java:415)
	at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:378)
	at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:356)
	at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:70)
	at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:429)
	at org.jboss.resteasy.core.SynchronousDispatcher.lambda$invoke$4(SynchronousDispatcher.java:240)
	at org.jboss.resteasy.core.SynchronousDispatcher.lambda$preprocess$0(SynchronousDispatcher.java:154)
	at org.jboss.resteasy.core.interception.jaxrs.PreMatchContainerRequestContext.filter(PreMatchContainerRequestContext.java:321)
	at org.jboss.resteasy.core.SynchronousDispatcher.preprocess(SynchronousDispatcher.java:157)
	at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:229)
	at org.jboss.resteasy.plugins.server.servlet.ServletContainerDispatcher.service(ServletContainerDispatcher.java:222)
	at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:55)
	at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:51)
	at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:614)
	at org.eclipse.jetty.ee10.servlet.ServletHolder.handle(ServletHolder.java:736)
	at org.eclipse.jetty.ee10.servlet.ServletHandler$ChainEnd.doFilter(ServletHandler.java:1614)
	at org.eclipse.jetty.ee10.servlet.ServletHandler$MappedServlet.handle(ServletHandler.java:1547)
	at org.eclipse.jetty.ee10.servlet.ServletChannel.dispatch(ServletChannel.java:824)
	at org.eclipse.jetty.ee10.servlet.ServletChannel.handle(ServletChannel.java:436)
	at org.eclipse.jetty.ee10.servlet.ServletHandler.handle(ServletHandler.java:464)
	at org.eclipse.jetty.server.handler.ContextHandler.handle(ContextHandler.java:858)
	at org.eclipse.jetty.server.Server.handle(Server.java:181)
	at org.eclipse.jetty.server.internal.HttpChannelState$HandlerInvoker.run(HttpChannelState.java:648)
	at org.eclipse.jetty.server.internal.HttpConnection.onFillable(HttpConnection.java:403)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:322)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:99)
	at org.eclipse.jetty.io.SelectableChannelEndPoint$1.run(SelectableChannelEndPoint.java:53)
	at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.runTask(AdaptiveExecutionStrategy.java:478)
	at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.consumeTask(AdaptiveExecutionStrategy.java:441)
	at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.tryProduce(AdaptiveExecutionStrategy.java:293)
	at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.run(AdaptiveExecutionStrategy.java:201)
	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:311)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:979)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.doRunJob(QueuedThreadPool.java:1209)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1164)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.ExceptionInInitializerError [in thread "qtp1476394199-41"]
	at java.base/javax.crypto.Cipher.getInstance(Cipher.java:549)
	at java.base/sun.security.ssl.SSLCipher.isTransformationAvailable(SSLCipher.java:477)
	at java.base/sun.security.ssl.SSLCipher.<init>(SSLCipher.java:466)
	at java.base/sun.security.ssl.SSLCipher.<clinit>(SSLCipher.java:90)
	at java.base/sun.security.ssl.CipherSuite.<clinit>(CipherSuite.java:65)
	at java.base/sun.security.ssl.SSLContextImpl.getApplicableSupportedCipherSuites(SSLContextImpl.java:334)
	at java.base/sun.security.ssl.SSLContextImpl$AbstractTLSContext.<clinit>(SSLContextImpl.java:547)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:421)
	at java.base/java.lang.Class.forName(Class.java:412)
	at java.base/java.security.Provider$Service.getImplClass(Provider.java:1993)
	at java.base/java.security.Provider$Service.getDefaultConstructor(Provider.java:2024)
	at java.base/java.security.Provider$Service.newInstanceOf(Provider.java:1938)
	at java.base/java.security.Provider$Service.newInstanceUtil(Provider.java:1946)
	at java.base/java.security.Provider$Service.newInstance(Provider.java:1921)
	at java.base/sun.security.jca.GetInstance.getInstance(GetInstance.java:236)
	at java.base/sun.security.jca.GetInstance.getInstance(GetInstance.java:164)
	at java.base/javax.net.ssl.SSLContext.getInstance(SSLContext.java:185)
	at java.base/javax.net.ssl.SSLContext.getDefault(SSLContext.java:110)
	at java.net.http/jdk.internal.net.http.HttpClientImpl.<init>(HttpClientImpl.java:460)
	at java.net.http/jdk.internal.net.http.HttpClientImpl.create(HttpClientImpl.java:436)
	at java.net.http/jdk.internal.net.http.HttpClientBuilderImpl.build(HttpClientBuilderImpl.java:143)
	at org.apache.solr.client.solrj.impl.HttpJdkSolrClient.<init>(HttpJdkSolrClient.java:133)
	at org.apache.solr.client.solrj.impl.HttpJdkSolrClient$Builder.build(HttpJdkSolrClient.java:583)
	at org.ndexbio.SingleNetworkSolrIdxManager.<init>(SingleNetworkSolrIdxManager.java:76)
	at org.ndexbio.SingleNetworkSolrIdxManager.<init>(SingleNetworkSolrIdxManager.java:85)
	at org.ndexbio.MessageResource.findStartingNodeIds(MessageResource.java:120)
	at org.ndexbio.MessageResource.queryNetwork(MessageResource.java:191)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.jboss.resteasy.core.MethodInjectorImpl.invoke(MethodInjectorImpl.java:154)
	at org.jboss.resteasy.core.MethodInjectorImpl.invoke(MethodInjectorImpl.java:118)
	at org.jboss.resteasy.core.ResourceMethodInvoker.internalInvokeOnTarget(ResourceMethodInvoker.java:560)
	at org.jboss.resteasy.core.ResourceMethodInvoker.invokeOnTargetAfterFilter(ResourceMethodInvoker.java:452)
	at org.jboss.resteasy.core.ResourceMethodInvoker.lambda$invokeOnTarget$2(ResourceMethodInvoker.java:413)
	at org.jboss.resteasy.core.interception.jaxrs.PreMatchContainerRequestContext.filter(PreMatchContainerRequestContext.java:321)
	at org.jboss.resteasy.core.ResourceMethodInvoker.invokeOnTarget(ResourceMethodInvoker.java:415)
	at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:378)
	at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:356)
	at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:70)
	at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:429)
	at org.jboss.resteasy.core.SynchronousDispatcher.lambda$invoke$4(SynchronousDispatcher.java:240)
	at org.jboss.resteasy.core.SynchronousDispatcher.lambda$preprocess$0(SynchronousDispatcher.java:154)
	at org.jboss.resteasy.core.interception.jaxrs.PreMatchContainerRequestContext.filter(PreMatchContainerRequestContext.java:321)
	at org.jboss.resteasy.core.SynchronousDispatcher.preprocess(SynchronousDispatcher.java:157)
	at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:229)
	at org.jboss.resteasy.plugins.server.servlet.ServletContainerDispatcher.service(ServletContainerDispatcher.java:222)
	at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:55)
	at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:51)
	at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:614)
	at org.eclipse.jetty.ee10.servlet.ServletHolder.handle(ServletHolder.java:736)
	at org.eclipse.jetty.ee10.servlet.ServletHandler$ChainEnd.doFilter(ServletHandler.java:1614)
	at org.eclipse.jetty.ee10.servlet.ServletHandler$MappedServlet.handle(ServletHandler.java:1547)
	at org.eclipse.jetty.ee10.servlet.ServletChannel.dispatch(ServletChannel.java:824)
	at org.eclipse.jetty.ee10.servlet.ServletChannel.handle(ServletChannel.java:436)
	at org.eclipse.jetty.ee10.servlet.ServletHandler.handle(ServletHandler.java:464)
	at org.eclipse.jetty.server.handler.ContextHandler.handle(ContextHandler.java:858)
	at org.eclipse.jetty.server.Server.handle(Server.java:181)
	at org.eclipse.jetty.server.internal.HttpChannelState$HandlerInvoker.run(HttpChannelState.java:648)
	at org.eclipse.jetty.server.internal.HttpConnection.onFillable(HttpConnection.java:403)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:322)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:99)
	at org.eclipse.jetty.io.SelectableChannelEndPoint$1.run(SelectableChannelEndPoint.java:53)

```

Fixes [CW-708](https://cytoscape.atlassian.net/browse/CW-708)